### PR TITLE
fix: Make deploy script work across more systems

### DIFF
--- a/deploy
+++ b/deploy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # fix permissions on local dirs
 chmod 777 ./auditlogs


### PR DESCRIPTION
Using /usr/bin/env to find the bash interpreter is a standard pattern,
and will work across more systems than hardcoding the path.